### PR TITLE
resp_delay module

### DIFF
--- a/src/lib/modules/response/resp_delay.go
+++ b/src/lib/modules/response/resp_delay.go
@@ -1,0 +1,55 @@
+package response
+
+import (
+	"fmt"
+	"math"
+	"net/http"
+	"time"
+)
+
+// Route struct
+type Route struct {
+	url         string
+	requestType string
+}
+
+// HandleResponseDelayForRoute is the initial entrypoint function for this module which takes
+// in a Route struct and supplies it to a function in turn to handle it accordingly. We create
+// channels to run tests for each route in parallel, speeding up the process
+func HandleResponseDelayForRoute(route Route) int {
+	c := make(chan int)
+	go RouteDispatcher(route, c)
+	timeElapsed := <-c
+	return timeElapsed
+}
+
+// RouteDispatcher dispatches a route to respective handlers based on it's request type
+func RouteDispatcher(route Route, c chan int) {
+	if route.requestType == "GET" {
+		respTime := HandleGetRequest(route.url)
+		c <- respTime
+	} else {
+		// Send a very large integer to automatically rule out as it
+		// is much much larger than the threshold
+		c <- math.MaxInt32
+	}
+}
+
+// HandleGetRequest specifically handles routes with GET Requests. Calculates timestamp before
+// and after processing of each request and returns the difference
+func HandleGetRequest(url string) int {
+	// Time init
+	start := time.Now().UnixNano()
+
+	resp, err := http.Get(url)
+	if err != nil {
+		// Prone to alerting, printing for now
+		fmt.Println(err)
+	}
+	defer resp.Body.Close()
+
+	end := time.Now().UnixNano()
+	diff := int((end - start) / int64(time.Millisecond))
+
+	return diff
+}

--- a/src/lib/modules/response/resp_delay_test.go
+++ b/src/lib/modules/response/resp_delay_test.go
@@ -1,0 +1,45 @@
+package response
+
+import (
+	"log"
+	"math"
+	"testing"
+)
+
+const (
+	threshold = 0
+)
+
+var routes = []Route{
+	Route{
+		"https://www.zairza.in/",
+		"GET",
+	},
+	Route{
+		"http://www.zairza.in",
+		"OPTIONS",
+	},
+}
+
+// what happens when requests other than GET, POST, PUT, DELETE hop in
+func TestRouteDispatcherForUnmentionedRequestTypes(t *testing.T) {
+	routeToTest := routes[1]
+	res := HandleResponseDelayForRoute(routeToTest)
+	// Output: Should return a large Integer
+	if res != math.MaxInt32 {
+		t.Errorf("should return a large integer to automatically rule out of threshold")
+	}
+	log.Println(res)
+}
+
+// Test if routes that have larger delays in response times
+// are conveyed to the user via the alerter
+func TestIfLargerReponseDelaysAreProneToAlert(t *testing.T) {
+	routeToTest := routes[0]
+	res := HandleResponseDelayForRoute(routeToTest)
+	// Output: res > threshold, Prone to alerting
+	if res < threshold {
+		t.Errorf("Invalid result. Expected result > threshold")
+	}
+	log.Println(res)
+}


### PR DESCRIPTION
This is an initial commit for calculating `request-response` delays, aimed at fixing #12. 