### PR TITLE
Remove chunk_ping files due to inconsistency

### DIFF
--- a/storage/ping/chunk_ping_�Q�3�}$��Ů���KF��.json
+++ b/storage/ping/chunk_ping_�Q�3�}$��Ů���KF��.json
@@ -1,1 +1,0 @@
-[{"datapoint":{"Min":85.657,"Mean":88.233,"Max":105.972,"MDev":5.937},"normalizedTime":0,"timestamp":"2019-10-02T22:03:16.860767234+05:30"}]

--- a/storage/ping/chunk_ping_�`���p�v�J�[z�)�.json
+++ b/storage/ping/chunk_ping_�`���p�v�J�[z�)�.json
@@ -1,1 +1,0 @@
-[{"datapoint":{"Min":42.681,"Mean":43.159,"Max":43.481,"MDev":0.42},"normalizedTime":0,"timestamp":"2019-10-02T22:27:09.410199904+05:30"}]


### PR DESCRIPTION
Can't git pull or rebase from upstream because these files have an illegal byte sequence "for Mac OS exclusively".

If we do not need these files in the repository, we can remove them else renaming them is also an option but yeah, they are created as a numeric hash

[Source of mercurial-scm](https://bz.mercurial-scm.org/show_bug.cgi?id=5762)