### PR TITLE
Enhancing ping scrap

### DIFF
--- a/src/lib/filters/scraps/scrapPing.go
+++ b/src/lib/filters/scraps/scrapPing.go
@@ -21,8 +21,9 @@ func strToFloat64(s string) float64 {
 // CLIPingScrap scraps the data points for CLIPing function
 func CLIPingScrap(s *string) (a *TypePingScrap) {
 	arr := strings.Split(*s, "\n")
-	for _, lines := range arr {
-		words := strings.Split(lines, " ")
+	l := len(arr)
+	if l > 2 {
+		words := strings.Split(arr[l-2], " ")
 		if words[0] == "rtt" {
 			temp := strings.Split(words[len(words)-2], "/")
 			a = &TypePingScrap{


### PR DESCRIPTION
Signed-off-by: muskankhedia <muskan.khedia2000@gmail.com>

Fixes: #53 
The ping module in Bench Routes is the most prominent feature and used on a larger scale. Having the time-complexity as `O(N)` decreases the workflow and increases the time computational time. So the scrapping has been enhanced to the time-complexity as `O(1)`.