### PR TITLE
create path in storage if not found

### DIFF
--- a/tsdb/parse.go
+++ b/tsdb/parse.go
@@ -53,7 +53,10 @@ func checkAndCreatePath(path string) {
 	path = strings.Join(array, "/")
 	_, err := os.Stat(path)
 	if err != nil {
-		os.MkdirAll(path, os.ModePerm)
+		e := os.MkdirAll(path, os.ModePerm)
+		if e != nil {
+			panic(e)
+		}
 	}
 }
 

--- a/tsdb/parse.go
+++ b/tsdb/parse.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"errors"
 	"io/ioutil"
+	"os"
+	"strings"
 )
 
 func parse(path string) (*string, error) {
@@ -45,7 +47,18 @@ func loadFromStorageFloodPing(raw *string) *[]BlockFloodPingJSON {
 	return &inst
 }
 
+func checkAndCreatePath(path string) {
+	array := strings.Split(path, "/")
+	array = array[:len(array)-1]
+	path = strings.Join(array, "/")
+	_, err := os.Stat(path)
+	if err != nil {
+		os.MkdirAll(path, os.ModePerm)
+	}
+}
+
 func saveToHDD(path string, data []byte) error {
+	checkAndCreatePath(path)
 	e := ioutil.WriteFile(path, data, 0755)
 	if e != nil {
 		return e


### PR DESCRIPTION
Signed-off-by: ankitjena <ankitjena13@gmail.com>

Fixes #69  .Check for path when writing to HDD, in case path doesn't exist create one.