### PR TITLE
Fixed pipe error in ping

### DIFF
--- a/src/lib/filters/scraps/scrapPing.go
+++ b/src/lib/filters/scraps/scrapPing.go
@@ -30,7 +30,7 @@ func CLIPingScrap(s *string) (a *TypePingScrap) {
 	if l > 2 {
 		words := strings.Split(arr[l-2], " ")
 		if words[0] == "rtt" {
-			temp := strings.Split(words[len(words)-2], "/")
+			temp := strings.Split(words[3], "/")
 			a = &TypePingScrap{
 				Min:  strToFloat64(temp[0]),
 				Avg:  strToFloat64(temp[1]),


### PR DESCRIPTION
Signed-off-by: muskankhedia <muskan.khedia2000@gmail.com>

Fixes: #52 

The pipe error in ping was due to the different outputs of ping command at some instant. So the scrapping has been modified to avoid such errors.