### PR TITLE
Error handling in ping/flood-ping/jitter functionality

### DIFF
--- a/src/lib/modules/jitter/jitter.go
+++ b/src/lib/modules/jitter/jitter.go
@@ -6,6 +6,7 @@ import (
 	"github.com/zairza-cetb/bench-routes/tsdb"
 	"sync"
 	"time"
+	"log"
 )
 
 const (
@@ -15,12 +16,13 @@ const (
 
 //HandleJitter handles the url and calculate the jitter for that url
 func HandleJitter(globalChain []*tsdb.Chain, url string, packets int, tsdbNameHash string, wg *sync.WaitGroup, isTest bool) {
-
-	chnl := make(chan *string)
 	tsdbNameHash = PathJitter + "/" + "chunk_jitter_" + tsdbNameHash + ".json"
-	// launch a goroutine to handle ping operations
-	go utils.CLIPing(url, packets, chnl)
-	resp := <-chnl
+	resp, err := utils.CLIPing(url, packets)
+	if err != nil {
+		log.Println(*resp)
+		wg.Done()
+		return
+	}
 	result := scrap.CLIJitterScrap(resp)
 	newBlock := createNewBlock(result)
 	urlExists := false

--- a/src/lib/modules/jitter/jitter.go
+++ b/src/lib/modules/jitter/jitter.go
@@ -4,9 +4,9 @@ import (
 	scrap "github.com/zairza-cetb/bench-routes/src/lib/filters/scraps"
 	"github.com/zairza-cetb/bench-routes/src/lib/utils"
 	"github.com/zairza-cetb/bench-routes/tsdb"
+	"log"
 	"sync"
 	"time"
-	"log"
 )
 
 const (

--- a/src/lib/modules/ping/flood_ping.go
+++ b/src/lib/modules/ping/flood_ping.go
@@ -7,6 +7,7 @@ import (
 	scrap "github.com/zairza-cetb/bench-routes/src/lib/filters/scraps"
 	"github.com/zairza-cetb/bench-routes/src/lib/utils"
 	"github.com/zairza-cetb/bench-routes/tsdb"
+	"log"
 )
 
 // const (
@@ -16,12 +17,14 @@ import (
 
 // HandleFloodPing is the main handler for flood ping operations
 func HandleFloodPing(globalChain []*tsdb.ChainFloodPing, urlRaw string, packets int, tsdbNameHash string, wg *sync.WaitGroup, isTest bool, password string) {
-	chnl := make(chan *string)
 
 	tsdbNameHash = utils.PathFloodPing + "/" + "chunk_flood_ping_" + tsdbNameHash + ".json"
-	// launch a goroutine to handle ping operations
-	go utils.CLIFloodPing(urlRaw, packets, chnl, password)
-	resp := <-chnl
+	resp, err := utils.CLIFloodPing(urlRaw, packets, password)
+	if err != nil {
+		log.Println(*resp)
+		wg.Done()
+		return
+	}
 	result := *scrap.CLIFLoodPingScrap(resp)
 	newBlock := createNewBlockFloodPing(result)
 	urlExists := false

--- a/src/lib/modules/ping/ping.go
+++ b/src/lib/modules/ping/ping.go
@@ -4,9 +4,9 @@ import (
 	scrap "github.com/zairza-cetb/bench-routes/src/lib/filters/scraps"
 	"github.com/zairza-cetb/bench-routes/src/lib/utils"
 	"github.com/zairza-cetb/bench-routes/tsdb"
+	"log"
 	"sync"
 	"time"
-	"log"
 )
 
 // const (

--- a/src/lib/modules/ping/ping.go
+++ b/src/lib/modules/ping/ping.go
@@ -6,6 +6,7 @@ import (
 	"github.com/zairza-cetb/bench-routes/tsdb"
 	"sync"
 	"time"
+	"log"
 )
 
 // const (
@@ -15,12 +16,14 @@ import (
 
 // HandlePing is the main handler for ping operations
 func HandlePing(globalChain []*tsdb.ChainPing, urlRaw string, packets int, tsdbNameHash string, wg *sync.WaitGroup, isTest bool) {
-	chnl := make(chan *string)
-
 	tsdbNameHash = utils.PathPing + "/" + "chunk_ping_" + tsdbNameHash + ".json"
 	// launch a goroutine to handle ping operations
-	go utils.CLIPing(urlRaw, packets, chnl)
-	resp := <-chnl
+	resp, err := utils.CLIPing(urlRaw, packets)
+	if err != nil {
+		log.Println(*resp)
+		wg.Done()
+		return
+	}
 	result := *scrap.CLIPingScrap(resp)
 	newBlock := createNewBlock(result)
 	urlExists := false

--- a/src/lib/utils/http.go
+++ b/src/lib/utils/http.go
@@ -22,28 +22,23 @@ const (
 // Use of pointers necessary since the data received is of large size, thereby slowing the traditional
 // method of variables, as using variables require the time involved in loading into and out from cpu registers.
 // Specifying addresses directly speeds the entire process manyfolds.
-func CLIPing(url string, packets int, cliPingChannel chan *string) {
+func CLIPing(url string, packets int) (*string, error) {
 	url = *filters.HTTPPingFilter(&url)
-	cmd, err := exec.Command(CmdPingBasedOnPacketsNumber, "-c", strconv.Itoa(packets), url).Output()
-	if err != nil {
-		panic(err)
-	}
-	cmdStr := string(cmd)
-	cliPingChannel <- &cmdStr
+	cmd := exec.Command(CmdPingBasedOnPacketsNumber, "-c", strconv.Itoa(packets), url)
+	cmdOutput, err := cmd.CombinedOutput()
+	cmdStr := string(cmdOutput)
+	return &cmdStr, err
 }
 
 // CLIFloodPing in another subroutine, for ping operation with -f flag
 // which sends multiple ping request at once i.e. floods the url with requests.
-func CLIFloodPing(url string, packets int, cliPingChannel chan *string, password string) {
+func CLIFloodPing(url string, packets int, password string) (*string, error){
 	url = *filters.HTTPPingFilter(&url)
 	cmd := fmt.Sprintf("%s -e \"%s\n\" | %s -S %s -f -c %s %s", CmdEcho, password, CmdAdministrator, CmdPingBasedOnPacketsNumber, strconv.Itoa(packets), url)
-
-	cmdPing, err := exec.Command("bash", "-c", cmd).Output()
-	if err != nil {
-		panic(err)
-	}
-	cmdStr := string(cmdPing)
-	cliPingChannel <- &cmdStr
+	cmdPing := exec.Command("bash", "-c", cmd)
+	cmdOuput, err := cmdPing.CombinedOutput()
+	cmdStr := string(cmdOuput)
+	return &cmdStr, err
 }
 
 //SendGETRequest sends http GET request to the specified url(both resp_delay and monitor_response_status module use it)

--- a/src/lib/utils/http.go
+++ b/src/lib/utils/http.go
@@ -32,7 +32,7 @@ func CLIPing(url string, packets int) (*string, error) {
 
 // CLIFloodPing in another subroutine, for ping operation with -f flag
 // which sends multiple ping request at once i.e. floods the url with requests.
-func CLIFloodPing(url string, packets int, password string) (*string, error){
+func CLIFloodPing(url string, packets int, password string) (*string, error) {
 	url = *filters.HTTPPingFilter(&url)
 	cmd := fmt.Sprintf("%s -e \"%s\n\" | %s -S %s -f -c %s %s", CmdEcho, password, CmdAdministrator, CmdPingBasedOnPacketsNumber, strconv.Itoa(packets), url)
 	cmdPing := exec.Command("bash", "-c", cmd)

--- a/src/lib/utils/http_test.go
+++ b/src/lib/utils/http_test.go
@@ -34,7 +34,7 @@ func TestCLIPing(t *testing.T) {
 
 	// testing packets on permutative urls
 	for _, ele := range urlsPermute {
-		resp, err := CLIPing(ele, 2)
+		_, err := CLIPing(ele, 2)
 		if err != nil {
 			t.Errorf("err requesting %s\n", ele)
 		}

--- a/src/lib/utils/http_test.go
+++ b/src/lib/utils/http_test.go
@@ -24,22 +24,18 @@ var (
 func TestCLIPing(t *testing.T) {
 	// testing packets on diff urls
 	for _, ele := range urlsDiff {
-		chnlCLICommunication := make(chan *string)
-		go CLIPing(ele, 2, chnlCLICommunication)
-		resp := *(<-chnlCLICommunication)
-		if len(resp) == 0 {
+		resp, err := CLIPing(ele, 2)
+		if err != nil {
 			t.Errorf("err requesting %s\n", ele)
 		} else {
-			t.Logf("%s\n", resp)
+			t.Logf("%s\n", *resp)
 		}
 	}
 
 	// testing packets on permutative urls
 	for _, ele := range urlsPermute {
-		chnlCLICommunication := make(chan *string)
-		go CLIPing(ele, 2, chnlCLICommunication)
-		resp := *(<-chnlCLICommunication)
-		if len(resp) == 0 {
+		resp, err := CLIPing(ele, 2)
+		if err != nil {
 			t.Errorf("err requesting %s\n", ele)
 		}
 	}


### PR DESCRIPTION
* Handling error cases while running 'ping' command
* Run CLIPing()/CLIFloodPing() as normal go functions and not
  as go routines.

Signed-off-by: Pratik Shinde <pratikshinde320@gmail.com>

Tested the code with socket tester.