### PR TITLE
code for saving logs to files.

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -1,15 +1,19 @@
 package main
 
 import (
+	"fmt"
 	"github.com/gorilla/websocket"
 	"github.com/zairza-cetb/bench-routes/src/lib/filters"
 	"github.com/zairza-cetb/bench-routes/src/lib/utils"
 	"github.com/zairza-cetb/bench-routes/src/lib/utils/parser"
 	"github.com/zairza-cetb/bench-routes/tsdb"
+	"io"
 	"log"
 	"net/http"
 	"os"
+	"os/user"
 	"strconv"
+	"time"
 )
 
 var (
@@ -22,10 +26,12 @@ var (
 	configuration parser.YAMLBenchRoutesType
 )
 
-func init() {
+const (
+	logFilePrefix = "bench-route-"
+)
 
-	log.SetPrefix("LOG: ")
-	log.SetFlags(log.Ldate | log.Lmicroseconds | log.LstdFlags | log.Lshortfile)
+func init() {
+	setupLogger()
 	log.Printf("initializing bench-routes ...")
 
 	// load configuration file
@@ -220,4 +226,25 @@ func main() {
 	// launch service
 	log.Fatal(http.ListenAndServe(port, nil))
 
+}
+
+func setupLogger() {
+	currTime := time.Now()
+	currFileName := fmt.Sprint(logFilePrefix, currTime.Format("2006-01-02#15:04:05"), ".log")
+	user, err := user.Current()
+	if err != nil {
+		fmt.Printf("cannot access current user data\n")
+		return
+	}
+	homePath := user.HomeDir
+	logFilePath := homePath + "/" + currFileName
+	file, err := os.OpenFile(logFilePath, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+	if err != nil {
+		fmt.Printf("error opening log file : %s\n", logFilePath)
+		return
+	}
+	writer := io.MultiWriter(os.Stdout, file)
+	log.SetOutput(writer)
+	log.SetPrefix("LOG: ")
+	log.SetFlags(log.Ldate | log.Lmicroseconds | log.Llongfile)
 }

--- a/src/main.go
+++ b/src/main.go
@@ -28,6 +28,7 @@ var (
 
 const (
 	logFilePrefix = "bench-route-"
+	logDirectory  = "br-logs"
 )
 
 func init() {
@@ -236,9 +237,16 @@ func setupLogger() {
 		fmt.Printf("cannot access current user data\n")
 		return
 	}
+
 	homePath := user.HomeDir
-	logFilePath := homePath + "/" + currFileName
-	file, err := os.OpenFile(logFilePath, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+	logDirectoryPath := homePath + "/" + logDirectory
+	err = os.MkdirAll(logDirectoryPath, 0755)
+	if err != nil {
+		fmt.Printf("error creating log directory : %s\n", logDirectoryPath)
+		return
+	}
+	logFilePath := logDirectoryPath + "/" + currFileName
+	file, err := os.OpenFile(logFilePath, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0644)
 	if err != nil {
 		fmt.Printf("error opening log file : %s\n", logFilePath)
 		return
@@ -246,5 +254,5 @@ func setupLogger() {
 	writer := io.MultiWriter(os.Stdout, file)
 	log.SetOutput(writer)
 	log.SetPrefix("LOG: ")
-	log.SetFlags(log.Ldate | log.Lmicroseconds | log.Llongfile)
+	log.SetFlags(log.Ldate | log.Lmicroseconds | log.Lshortfile)
 }

--- a/src/main.go
+++ b/src/main.go
@@ -246,7 +246,7 @@ func setupLogger() {
 		return
 	}
 	logFilePath := logDirectoryPath + "/" + currFileName
-	file, err := os.OpenFile(logFilePath, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0644)
+	file, err := os.OpenFile(logFilePath, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0444)
 	if err != nil {
 		fmt.Printf("error opening log file : %s\n", logFilePath)
 		return


### PR DESCRIPTION
Added code to save logs generated by bench-route to secondary storage.
The log file is created in current user's home directory with date & time.
Fixes: #37 

Signed-off-by: Pratik Shinde <pratikshinde320@gmail.com>

This creates a file with name : bench-route-<current-date-time>.log in current user's home directory.
logger writes to both stdout & logfile. We can add a command line option to bench-route utility to enable/disable stdout output.

Testing:
![logger](https://user-images.githubusercontent.com/17097242/66775935-d11eff80-eee2-11e9-8f4d-69bc2438debe.PNG)
![logger2](https://user-images.githubusercontent.com/17097242/66775936-d11eff80-eee2-11e9-9c58-b817912eb0fa.PNG)
