### PR TITLE
Merge BR-electron into bench-routes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "dashboard"]
+	path = dashboard
+	url = https://github.com/zairza-cetb/bench-routes-electron.git


### PR DESCRIPTION
**git** lets you add submodules referring to other repositories within a parent repository

Feat: Merged bench-routes-electron as dashboard inside bench-routes as a submodule, reconfigured prettier. 

### Motivation
Fixes the need to clone different repositories, also keeping track of two separate repositories. The older repository is still there preserving all the commit history.

Signed-off-by: Aquib Baig <aquibbaig97@gmail.com>