### PR TITLE
Extended api support for modules

### DIFF
--- a/dashboard/v1.0/src/components/layouts/Header.tsx
+++ b/dashboard/v1.0/src/components/layouts/Header.tsx
@@ -23,7 +23,7 @@ export default function Header() {
               src="assets/icons/notify-icon.svg"
               alt="notification"
               onClick={() => updateShowNotificationsScreen()}
-              onKeyDown={(e) => {
+              onKeyDown={e => {
                 if (e.keyCode === 13) {
                   updateShowNotificationsScreen();
                 }

--- a/dashboard/v1.0/src/components/layouts/Submenu.tsx
+++ b/dashboard/v1.0/src/components/layouts/Submenu.tsx
@@ -88,7 +88,7 @@ export default class Submenu extends React.Component<
                 <span>
                   <select
                     className="submenu-style-general"
-                    onChange={(e) => this.setState({ urlSlot: e.target.value })}
+                    onChange={e => this.setState({ urlSlot: e.target.value })}
                   >
                     <option />
                     {this.state.routes.length !== 0
@@ -104,7 +104,7 @@ export default class Submenu extends React.Component<
                 <span>
                   <select
                     className="submenu-style-general"
-                    onChange={(e) => this.setState({ urlSlot: e.target.value })}
+                    onChange={e => this.setState({ urlSlot: e.target.value })}
                   >
                     <option />
                     {this.state.routes.length !== 0

--- a/dashboard/v1.0/src/components/notification/Notification.tsx
+++ b/dashboard/v1.0/src/components/notification/Notification.tsx
@@ -22,7 +22,7 @@ export default class Notification extends React.Component<{
               alt="collapse notifications"
               className="notification-close"
               onClick={() => this.props.updateShowNotificationsScreen()}
-              onKeyDown={(e) => {
+              onKeyDown={e => {
                 if (e.keyCode === 13) {
                   return this.props.updateShowNotificationsScreen();
                 }

--- a/src/lib/modules/jitter/jitter.go
+++ b/src/lib/modules/jitter/jitter.go
@@ -29,7 +29,7 @@ type TestInterval struct {
 
 // Response is used to decode the tsdb while sending data in the API
 type Response struct {
-	Value string `json: "value"`
+	Value string `json:"value"`
 }
 
 // New returns a Jitter type.

--- a/src/lib/modules/jitter/jitter.go
+++ b/src/lib/modules/jitter/jitter.go
@@ -27,7 +27,7 @@ type TestInterval struct {
 	Duration int64
 }
 
-// Response is used to decode the tsdb while sending data in the API
+// Response is used to decode the tsdb blocks to data points that supports JSON encoding.
 type Response struct {
 	Value string `json:"value"`
 }

--- a/src/lib/modules/jitter/jitter.go
+++ b/src/lib/modules/jitter/jitter.go
@@ -27,6 +27,11 @@ type TestInterval struct {
 	Duration int64
 }
 
+// Response is used to decode the tsdb while sending data in the API
+type Response struct {
+	Value string `json: "value"`
+}
+
 // New returns a Jitter type.
 func New(configuration *parser.YAMLBenchRoutesType, scrapeInterval TestInterval, chain []*tsdb.Chain) *Jitter {
 	return &Jitter{

--- a/src/lib/modules/ping/flood_ping.go
+++ b/src/lib/modules/ping/flood_ping.go
@@ -34,11 +34,11 @@ func Newf(configuration *parser.YAMLBenchRoutesType, scrapeInterval TestInterval
 
 // FloodPingResponse is used to decode the tsdb while sending data in the API
 type FloodPingResponse struct {
-	Min   string `json: "minValue"`
-	Avg   string `json: "avgValue"`
-	Max   string `json: "maxValue"`
-	Mdev  string `json: "mdevValue"`
-	Ploss string `json: "packetLoss"`
+	Min   string `json:"minValue"`
+	Avg   string `json:"avgValue"`
+	Max   string `json:"maxValue"`
+	Mdev  string `json:"mdevValue"`
+	Ploss string `json:"packetLoss"`
 }
 
 // Iteratef iterates over the local-configuration file to keep state

--- a/src/lib/modules/ping/flood_ping.go
+++ b/src/lib/modules/ping/flood_ping.go
@@ -32,7 +32,16 @@ func Newf(configuration *parser.YAMLBenchRoutesType, scrapeInterval TestInterval
 	}
 }
 
-// Iterate iterates over the local-configuration file to keep state
+// FloodPingResponse is used to decode the tsdb while sending data in the API
+type FloodPingResponse struct {
+	Min   string `json: "minValue"`
+	Avg   string `json: "avgValue"`
+	Max   string `json: "maxValue"`
+	Mdev  string `json: "mdevValue"`
+	Ploss string `json: "packetLoss"`
+}
+
+// Iteratef iterates over the local-configuration file to keep state
 // of the ping service in sync with the local configuration.
 // It is responsible for stopping the service without damaging the currently
 // calculated samples.

--- a/src/lib/modules/ping/flood_ping.go
+++ b/src/lib/modules/ping/flood_ping.go
@@ -32,7 +32,7 @@ func Newf(configuration *parser.YAMLBenchRoutesType, scrapeInterval TestInterval
 	}
 }
 
-// FloodPingResponse is used to decode the tsdb while sending data in the API
+// FloodPingResponse is used to decode the tsdb blocks to data points that supports JSON encoding.
 type FloodPingResponse struct {
 	Min   string `json:"minValue"`
 	Avg   string `json:"avgValue"`

--- a/src/lib/modules/ping/ping.go
+++ b/src/lib/modules/ping/ping.go
@@ -27,7 +27,7 @@ type TestInterval struct {
 	Duration int64
 }
 
-// Response is used to decode the tsdb while sending data in the API
+// Response is used to decode the tsdb blocks to data points that supports JSON encoding.
 type Response struct {
 	Min  string `json:"minValue"`
 	Avg  string `json:"avgValue"`

--- a/src/lib/modules/ping/ping.go
+++ b/src/lib/modules/ping/ping.go
@@ -27,6 +27,14 @@ type TestInterval struct {
 	Duration int64
 }
 
+// Response is used to decode the tsdb while sending data in the API
+type Response struct {
+	Min  string `json: "minValue"`
+	Avg  string `json: "avgValue"`
+	Max  string `json: "maxValue"`
+	Mdev string `json: "mdevValue"`
+}
+
 // New returns a Ping type.
 func New(configuration *parser.YAMLBenchRoutesType, scrapeInterval TestInterval, chain []*tsdb.Chain) *Ping {
 	return &Ping{

--- a/src/lib/modules/ping/ping.go
+++ b/src/lib/modules/ping/ping.go
@@ -29,10 +29,10 @@ type TestInterval struct {
 
 // Response is used to decode the tsdb while sending data in the API
 type Response struct {
-	Min  string `json: "minValue"`
-	Avg  string `json: "avgValue"`
-	Max  string `json: "maxValue"`
-	Mdev string `json: "mdevValue"`
+	Min  string `json:"minValue"`
+	Avg  string `json:"avgValue"`
+	Max  string `json:"maxValue"`
+	Mdev string `json:"mdevValue"`
 }
 
 // New returns a Ping type.

--- a/src/lib/utils/decode/blocks-decoding.go
+++ b/src/lib/utils/decode/blocks-decoding.go
@@ -1,7 +1,6 @@
-package utils
+package decode
 
 import (
-	"github.com/zairza-cetb/bench-routes/src/metrics/system"
 	"github.com/zairza-cetb/bench-routes/tsdb"
 )
 
@@ -17,10 +16,19 @@ func NewBlockDecoding(Type string) *BlockDecodingBR {
 	}
 }
 
+// Decode function checks for different kinds of modules and redirects
+// the same to the respective functions to get the decoded value which
+// is to be passed to the front end
 func (bd *BlockDecodingBR) Decode(block tsdb.Block) interface{} {
 	switch bd.Type {
 	case "sys":
-		return system.Decode(block.Datapoint)
+		return systemDecode(block.Datapoint)
+	case "ping":
+		return pingDecode(block.Datapoint)
+	case "jitter":
+		return jitterDecode(block.Datapoint)
+	case "flood-ping":
+		return floodPingDecode(block.Datapoint)
 	}
 	return nil
 }

--- a/src/lib/utils/decode/module-decoding.go
+++ b/src/lib/utils/decode/module-decoding.go
@@ -1,0 +1,68 @@
+package decode
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/zairza-cetb/bench-routes/src/lib/modules/jitter"
+	"github.com/zairza-cetb/bench-routes/src/lib/modules/ping"
+	"github.com/zairza-cetb/bench-routes/src/metrics/system"
+)
+
+// System converts the block into Response type for easily http based
+// response.
+func systemDecode(block string) system.Response {
+	arr := strings.Split(block, "|")
+	if len(arr) != 8 {
+		panic(fmt.Errorf("Invalid block segments length: Segments must be 8 in number: length: %d", len(arr)))
+	}
+
+	return system.Response{
+		CPUTotalUsage: arr[0],
+		Memory: system.MemoryStatsStringified{
+			Total:       arr[1],
+			Available:   arr[2],
+			Used:        arr[3],
+			UsedPercent: arr[4],
+			Free:        arr[5],
+		},
+		Disk: system.DiskStatsStringified{
+			DiskIO: arr[6],
+			Cached: arr[7],
+		},
+	}
+}
+
+func pingDecode(block string) ping.Response {
+	arr := strings.Split(block, "|")
+	if len(arr) != 4 {
+		panic(fmt.Errorf("Invalid block segments length: Segments must be 8 in number: length: %d", len(arr)))
+	}
+	return ping.Response{
+		Min:  arr[0],
+		Avg:  arr[1],
+		Max:  arr[2],
+		Mdev: arr[3],
+	}
+}
+
+func jitterDecode(block string) jitter.Response {
+	arr := strings.Split(block, "|")
+	return jitter.Response{
+		Value: arr[0],
+	}
+}
+
+func floodPingDecode(block string) ping.FloodPingResponse {
+	arr := strings.Split(block, "|")
+	if len(arr) != 5 {
+		panic(fmt.Errorf("Invalid block segments length: Segments must be 8 in number: length: %d", len(arr)))
+	}
+	return ping.FloodPingResponse{
+		Min:   arr[0],
+		Avg:   arr[1],
+		Max:   arr[2],
+		Mdev:  arr[3],
+		Ploss: arr[4],
+	}
+}

--- a/src/lib/utils/decode/module-decoding.go
+++ b/src/lib/utils/decode/module-decoding.go
@@ -9,8 +9,7 @@ import (
 	"github.com/zairza-cetb/bench-routes/src/metrics/system"
 )
 
-// System converts the block into Response type for easily http based
-// response.
+// systemDecode converts the block into Response type for easy http based JSON response.
 func systemDecode(block string) system.Response {
 	arr := strings.Split(block, "|")
 	if len(arr) != 8 {

--- a/src/metrics/system/system.go
+++ b/src/metrics/system/system.go
@@ -148,7 +148,7 @@ func (s *SystemMetrics) Encode(block interface{}) string {
 	return data
 }
 
-// Response as http type for system-metrics response.
+// Response is used to decode the tsdb blocks to data points that supports JSON encoding.
 type Response struct {
 	CPUTotalUsage string                 `json:"cpuTotalUsage"`
 	Memory        MemoryStatsStringified `json:"memory"`

--- a/src/metrics/system/system.go
+++ b/src/metrics/system/system.go
@@ -2,7 +2,6 @@ package system
 
 import (
 	"fmt"
-	"strings"
 	"time"
 
 	disk "github.com/mackerelio/go-osstat/memory"
@@ -159,28 +158,4 @@ type Response struct {
 // Combine combines segments into a single data point for a block.
 func (s *SystemMetrics) Combine(cpu, memory, disk string) string {
 	return cpu + "|" + memory + "|" + disk
-}
-
-// Decode converts the block into Response type for easily http based
-// response.
-func Decode(block string) Response {
-	arr := strings.Split(block, "|")
-	if len(arr) != 8 {
-		panic(fmt.Errorf("Invalid block segments length: Segments must be 8 in number: length: %d", len(arr)))
-	}
-
-	return Response{
-		CPUTotalUsage: arr[0],
-		Memory: MemoryStatsStringified{
-			Total:       arr[1],
-			Available:   arr[2],
-			Used:        arr[3],
-			UsedPercent: arr[4],
-			Free:        arr[5],
-		},
-		Disk: DiskStatsStringified{
-			DiskIO: arr[6],
-			Cached: arr[7],
-		},
-	}
 }

--- a/tsdb/querier/querier.go
+++ b/tsdb/querier/querier.go
@@ -1,9 +1,10 @@
 package querier
 
 import (
-	"github.com/zairza-cetb/bench-routes/src/lib/utils"
 	"math"
 	"time"
+
+	"github.com/zairza-cetb/bench-routes/src/lib/utils/decode"
 
 	"github.com/zairza-cetb/bench-routes/tsdb"
 )
@@ -146,7 +147,7 @@ func (q *Query) exec(blockStream []tsdb.Block) []byte {
 		return q.ReturnNILResponse()
 	}
 	// decode the selected range of blocks
-	blocksDecoder := utils.NewBlockDecoding(resultingBlockSlice[0].Type)
+	blocksDecoder := decode.NewBlockDecoding(resultingBlockSlice[0].Type)
 	for i := range resultingBlockSlice {
 		decodedBlockStream = append(decodedBlockStream, queryValue{
 			Timestamp:      resultingBlockSlice[i].Timestamp,


### PR DESCRIPTION
Signed-off-by: muskankhedia <muskan.khedia2000@gmail.com>

Presently the API support was only for `sys` type of files. In this PR the support has been extended for `ping`, `jitter` and `floodping` types of files.