### PR TITLE
Extends ping and flood-ping support for mac and unix like systems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 os:
   - linux
-  - osx
 
 addons:
   chrome: stable
@@ -66,5 +65,4 @@ matrix:
         - cd tests/ && npm install chromedriver && cd ..
 
       script:
-#        - make test-views-v1.0
         - make test-views-v1.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 os:
   - linux
-  # - mac
+  - osx
 
 addons:
   chrome: stable

--- a/src/lib/filters/scraps/scrapPing.go
+++ b/src/lib/filters/scraps/scrapPing.go
@@ -1,9 +1,11 @@
 package scraps
 
 import (
-	"github.com/zairza-cetb/bench-routes/src/lib/utils"
 	"strconv"
 	"strings"
+
+	"github.com/zairza-cetb/bench-routes/src/lib/logger"
+	"github.com/zairza-cetb/bench-routes/src/lib/utils"
 )
 
 func strToFloat64(s string) float64 {
@@ -20,7 +22,7 @@ func CLIPingScrap(s *string) (a *utils.TypePingScrap) {
 	l := len(arr)
 	if l > 2 {
 		words := strings.Split(arr[l-2], " ")
-		if words[0] == "rtt" {
+		if words[0] == "rtt" || words[0] == "round-trip" {
 			temp := strings.Split(words[3], "/")
 			a = &utils.TypePingScrap{
 				Min:  strToFloat64(temp[0]),
@@ -36,17 +38,40 @@ func CLIPingScrap(s *string) (a *utils.TypePingScrap) {
 // CLIFLoodPingScrap returns packet loss
 func CLIFLoodPingScrap(s *string) (a *utils.TypeFloodPingScrap) {
 	arr := strings.Split(*s, "\n")
-	sentence := arr[3]
-	words := strings.Split(sentence, ", ")
+	var (
+		// Packetloss line is of the form:
+		// "10 packets transmitted, 2 packets received, 80.0% packet loss"
+		packetLossLine string
+		// PingValues line is of the form:
+		// round-trip min/avg/max/stddev = 91.299/96.281/101.264/4.983 ms (Mac OS/Unix like systems)
+		// rtt min/avg/max/stddev = 91.299/96.281/101.264/4.983 ms (Linux)
+		pingValuesLine string
+	)
+	for _, line := range arr {
+		if strings.Contains(line, "packet loss") {
+			packetLossLine = line
+		} else if strings.Contains(line, "round-trip") {
+			pingValuesLine = line
+		} else if strings.Contains(line, "rtt") {
+			pingValuesLine = line
+		}
+	}
+	// This error handler is for an optional security
+	// if we could not find suitable parameters in the
+	// ping command's output.
+	if packetLossLine == "" || pingValuesLine == "" {
+		logger.Terminal("p", "couldn't find a suitable response which contains packet loss")
+	}
+	words := strings.Split(packetLossLine, ", ")
 	packetLoss := strings.Split(words[2], " ")[0]
 
-	pingValuesString := strings.Split(arr[4], " ")[3]
+	pingValuesString := strings.Split((strings.Split(pingValuesLine, "= ")[1]), " ms")[0]
 	pingValues := strings.Split(pingValuesString, "/")
 	a = &utils.TypeFloodPingScrap{
 		Min:        strToFloat64(pingValues[0]),
 		Avg:        strToFloat64(pingValues[1]),
 		Max:        strToFloat64(pingValues[2]),
-		Mdev:       strToFloat64(pingValues[3]),
+		Mdev:       strToFloat64(strings.TrimRight(pingValues[3], " ms")),
 		PacketLoss: strToFloat64(strings.TrimRight(packetLoss, "%")),
 	}
 

--- a/src/lib/modules/ping/flood_ping.go
+++ b/src/lib/modules/ping/flood_ping.go
@@ -1,10 +1,11 @@
 package ping
 
 import (
-	"github.com/zairza-cetb/bench-routes/src/lib/filters"
-	"github.com/zairza-cetb/bench-routes/src/lib/parser"
 	"sync"
 	"time"
+
+	"github.com/zairza-cetb/bench-routes/src/lib/filters"
+	"github.com/zairza-cetb/bench-routes/src/lib/parser"
 
 	scrap "github.com/zairza-cetb/bench-routes/src/lib/filters/scraps"
 	"github.com/zairza-cetb/bench-routes/src/lib/logger"
@@ -154,9 +155,8 @@ func (ps *FloodPing) ping(urlRaw string, packets int, tsdbNameHash string, wg *s
 		wg.Done()
 		return
 	}
-
-	result := *scrap.CLIFLoodPingScrap(resp)
-	newBlock := *tsdb.GetNewBlock("flood-ping", getNormalizedBlockStringFlood(result))
+	result := scrap.CLIFLoodPingScrap(resp)
+	newBlock := *tsdb.GetNewBlock("flood-ping", getNormalizedBlockStringFlood(*result))
 	urlExists := false
 
 	c := ps.chain

--- a/src/lib/modules/ping/ping.go
+++ b/src/lib/modules/ping/ping.go
@@ -160,8 +160,8 @@ func (ps *Ping) ping(urlRaw string, packets int, tsdbNameHash string, wg *sync.W
 		return
 	}
 
-	result := *scrap.CLIPingScrap(resp)
-	newBlock := *tsdb.GetNewBlock("ping", getNormalizedBlockString(result))
+	result := scrap.CLIPingScrap(resp)
+	newBlock := *tsdb.GetNewBlock("ping", getNormalizedBlockString(*result))
 	urlExists := false
 
 	for index := range chain {

--- a/src/lib/utils/http.go
+++ b/src/lib/utils/http.go
@@ -24,9 +24,13 @@ const (
 // Specifying addresses directly speeds the entire process manyfolds.
 func CLIPing(url string, packets int) (*string, error) {
 	url = *filters.HTTPPingFilter(&url)
-	cmd := exec.Command(CmdPingBasedOnPacketsNumber, "-c", strconv.Itoa(packets), url)
-	cmdOutput, err := cmd.CombinedOutput()
-	cmdStr := string(cmdOutput)
+	cmd, err := exec.Command(CmdPingBasedOnPacketsNumber, "-c", strconv.Itoa(packets), url).Output()
+	if err != nil {
+		// There was an issue
+		// executing the command.
+		panic(err)
+	}
+	cmdStr := string(cmd)
 	return &cmdStr, err
 }
 
@@ -37,6 +41,11 @@ func CLIFloodPing(url string, packets int, password string) (*string, error) {
 	cmd := fmt.Sprintf("%s -e \"%s\n\" | %s -S %s -f -c %s %s", CmdEcho, password, CmdAdministrator, CmdPingBasedOnPacketsNumber, strconv.Itoa(packets), url)
 	cmdPing := exec.Command("bash", "-c", cmd)
 	cmdOuput, err := cmdPing.CombinedOutput()
+	if err != nil {
+		// There was an issue
+		// executing the command.
+		panic(err)
+	}
 	cmdStr := string(cmdOuput)
 	return &cmdStr, err
 }


### PR DESCRIPTION
- Extends ping and flood-ping support for Mac and Unix like systems.
- Fixed a few "dictator-like" code that caused us to explicitly pick substrings from predefined arrays. So made it a bit flexible.

Signed-off-by: Aquib Baig <aquibbaig97@gmail.com>