### PR TITLE
Add support for pprof in bench-routes

### DIFF
--- a/tests/package.json
+++ b/tests/package.json
@@ -17,7 +17,7 @@
   },
   "homepage": "https://github.com/zairza-cetb/bench-routes#readme",
   "dependencies": {
-    "chromedriver": "^80.0.1",
+    "chromedriver": "^83.0.0",
     "mocha": "^6.2.2",
     "selenium-webdriver": "^4.0.0-alpha.5"
   }


### PR DESCRIPTION
Aimed at fixing #226.
Exposes specific http endpoints to profiling using "pprof". There are a load bunch of other
things we can add support to. Need a discussion on that. By default I have added the following profiling options:
- go routine
- thread create
- block
- cmdline

Signed-off-by: Aquib Baig <aquibbaig97@gmail.com>