### PR TITLE
create a systemd file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,5 +11,12 @@ RUN npm install -g react-scripts yarn
 RUN cd dashboard/v1.1/ && yarn install && yarn run build
 RUN rm -R ui-builds/v1.1
 RUN cp -r dashboard/v1.1/build ui-builds/v1.1
+RUN cp ./bench-routes /usr/local/bin/
 EXPOSE 9090
-CMD [ "./bench-routes" ]
+
+# systemd configuration
+COPY src/lib/systemd/bench-routes.service /etc/systemd/
+RUN systemctl enable bench-routes.service
+RUN systemctl start bench-routes.service
+
+# CMD [ "./bench-routes" ]

--- a/src/lib/systemd/bench-routes.service
+++ b/src/lib/systemd/bench-routes.service
@@ -1,0 +1,19 @@
+# copy to: /etc/systemd/bench-routes.service
+# and run: systemctl daemon-reload
+# enable: systemctl enable bench-routes
+# start: systemctl start bench-routes
+
+[Unit]
+Description = Bench routes service
+Documentation = https://github.com/zairza-cetb/bench-routes
+After = network-online.target nss-lookup.target httpd-init.service
+
+[Service]
+Type = simple
+ExecStart = cd /usr/local/bin/ && ./bench-routes
+# ExecStop = clean ups
+Restart = always
+Environment = "GOPATH=$GOPATH"
+
+[Install]
+WantedBy = multi-user.target


### PR DESCRIPTION
Creates a systemd-service file.
- this file will be copied to the `/etc/systemd` folder when we install bench routes.
- ensure that all dependencies are properly installed before starting the service.
- start bench routes and dashboard in one service.
